### PR TITLE
Release build for aarch64 linux is failing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - target: aarch64-unknown-linux-gnu
-          os: ubuntu-24.04-arm
+        #- target: aarch64-unknown-linux-gnu
+        #  os: ubuntu-24.04-arm
         - target: x86_64-unknown-linux-gnu
           os: ubuntu-latest
         - target: x86_64-pc-windows-msvc


### PR DESCRIPTION
Not important for that release, so we can just comment it.